### PR TITLE
feat/conflict-ui

### DIFF
--- a/app/trips/[tripId]/activities/page.tsx
+++ b/app/trips/[tripId]/activities/page.tsx
@@ -199,6 +199,9 @@ const TimelinePage: React.FC = () => {
   );
 
   const hasOverlapWith = (cur: Activity, next: Activity): boolean => {
+    if (cur.hasOverlapConflict !== null && cur.hasOverlapConflict !== undefined) {
+      return cur.hasOverlapConflict;
+    }
     if (cur.gapToNextActivityMinutes !== null) return cur.gapToNextActivityMinutes < 0;
     return cur.date === next.date && toMinutes(cur.endTime) > toMinutes(next.startTime);
   };
@@ -235,9 +238,10 @@ const TimelinePage: React.FC = () => {
             const hasOverlap = overlapWithNext || overlapWithPrev;
 
             const gap = activity.gapToNextActivityMinutes;
-            const travel = travelTimes[activity.activityId] ?? activity.travelTimeToNextActivity ?? null;
+            const travel = activity.travelTimeToNextActivity ?? travelTimes[activity.activityId] ?? null;
             const freeTime = gap !== null && travel !== null ? gap - travel : null;
-            const hasTravelWarning = isSameDayAsNext && freeTime !== null && freeTime < 0 && gap !== null && gap >= 0;
+            const hasTravelWarning = isSameDayAsNext
+              && (activity.hasTravelTimeConflict ?? (freeTime !== null && freeTime < 0 && gap !== null && gap >= 0));
 
             const duration = formatDuration(activity.durationMinutes);
 

--- a/app/types/activity.ts
+++ b/app/types/activity.ts
@@ -11,4 +11,6 @@ export interface Activity {
   durationMinutes: number | null;
   travelTimeToNextActivity: number | null;
   gapToNextActivityMinutes: number | null;
+  hasOverlapConflict?: boolean | null;
+  hasTravelTimeConflict?: boolean | null;
 }


### PR DESCRIPTION
display server-driven conflict indicators in the timeline UI (#19, #20)

- highlight activities in red when they overlap with an adjacent activity
- show a warning when there is not enough time to travel between consecutive stops
- prioritize server-computed conflict data over local estimates for accuracy